### PR TITLE
Kuberneteize address and flavor

### DIFF
--- a/address-controller-lib/src/main/java/enmasse/address/controller/admin/FlavorManager.java
+++ b/address-controller-lib/src/main/java/enmasse/address/controller/admin/FlavorManager.java
@@ -34,7 +34,7 @@ public class FlavorManager implements FlavorRepository {
 
     @Override
     public Set<Flavor> getFlavors() {
-        return new HashSet<>(flavorMap.values());
+        return new LinkedHashSet<>(flavorMap.values());
     }
 
     @Override

--- a/address-controller-lib/src/main/java/enmasse/address/controller/api/v3/Address.java
+++ b/address-controller-lib/src/main/java/enmasse/address/controller/api/v3/Address.java
@@ -56,7 +56,7 @@ public class Address {
             ObjectNode node = mapper.createObjectNode();
             Destination destination = value.destination;
 
-            node.put(ResourceKeys.KIND, "Address");
+            node.put(ResourceKeys.KIND, kind());
             node.put(ResourceKeys.APIVERSION, "v3");
             node.put(ResourceKeys.STATUS, "/api/v3/status/" + destination.address());
 
@@ -64,7 +64,7 @@ public class Address {
             metadata.put(ResourceKeys.NAME, destination.address());
             destination.uuid().ifPresent(u -> metadata.put(ResourceKeys.UUID, u));
 
-            ObjectNode spec = node.putObject("spec");
+            ObjectNode spec = node.putObject(ResourceKeys.SPEC);
             spec.put(ResourceKeys.STORE_AND_FORWARD, destination.storeAndForward());
             spec.put(ResourceKeys.MULTICAST, destination.multicast());
             spec.put(ResourceKeys.GROUP, destination.group());

--- a/address-controller-lib/src/main/java/enmasse/address/controller/api/v3/FlavorList.java
+++ b/address-controller-lib/src/main/java/enmasse/address/controller/api/v3/FlavorList.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import enmasse.address.controller.model.Flavor;
 
@@ -37,18 +38,14 @@ public class FlavorList {
         @Override
         public void serialize(FlavorList value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
             ObjectNode node = mapper.createObjectNode();
-            Set<Flavor> flavors = value.flavors;
 
             node.put(ResourceKeys.KIND, kind());
             node.put(ResourceKeys.APIVERSION, "v3");
 
-            ObjectNode flavorsNode = node.putObject(ResourceKeys.FLAVORS);
+            ArrayNode items = node.putArray(ResourceKeys.ITEMS);
 
-            for (Flavor flavor : flavors) {
-                ObjectNode flavorNode = flavorsNode.putObject(flavor.name());
-                flavorNode.put(ResourceKeys.TYPE, flavor.type());
-                flavorNode.put(ResourceKeys.DESCRIPTION, flavor.description());
-                flavor.uuid().ifPresent(u -> flavorNode.put(ResourceKeys.UUID, u));
+            for (Flavor flavor : value.flavors) {
+                items.add(mapper.valueToTree(new enmasse.address.controller.api.v3.Flavor(flavor)));
             }
             mapper.writeValue(gen, node);
         }

--- a/address-controller-lib/src/main/java/enmasse/address/controller/api/v3/InstanceList.java
+++ b/address-controller-lib/src/main/java/enmasse/address/controller/api/v3/InstanceList.java
@@ -43,7 +43,7 @@ public class InstanceList {
         public InstanceList deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
             ObjectNode node = mapper.readValue(p, ObjectNode.class);
 
-            ArrayNode items = (ArrayNode) node.get(ResourceKeys.ITEMS);
+            ArrayNode items = node.has(ResourceKeys.ITEMS) ? (ArrayNode) node.get(ResourceKeys.ITEMS) : mapper.createArrayNode();
             Set<Instance> instances = new HashSet<>();
             for (int i = 0; i < items.size(); i++) {
                 instances.add(mapper.convertValue(items.get(i), enmasse.address.controller.api.v3.Instance.class).getInstance());

--- a/address-controller-lib/src/main/java/enmasse/address/controller/api/v3/ResourceKeys.java
+++ b/address-controller-lib/src/main/java/enmasse/address/controller/api/v3/ResourceKeys.java
@@ -11,7 +11,6 @@ public interface ResourceKeys {
     String FLAVOR = "flavor";
     String SPEC = "spec";
     String STATUS = "status";
-    String ADDRESSES = "addresses";
     String FLAVORS = "flavors";
     String TYPE = "type";
     String DESCRIPTION = "description";

--- a/address-controller-lib/src/main/java/enmasse/address/controller/parser/FlavorParser.java
+++ b/address-controller-lib/src/main/java/enmasse/address/controller/parser/FlavorParser.java
@@ -28,6 +28,7 @@ import java.util.Optional;
  * Parser for the flavor config.
  */
 public class FlavorParser {
+    private static final String KEY_NAME = "name";
     private static final String KEY_TEMPLATE_NAME = "templateName";
     private static final String KEY_TEMPLATE_PARAMETERS = "templateParameters";
     private static final String KEY_TYPE = "type";
@@ -36,17 +37,15 @@ public class FlavorParser {
 
     public static Map<String, Flavor> parse(JsonNode root) {
         Map<String, Flavor> flavorMap = new LinkedHashMap<>();
-        Iterator<Map.Entry<String, JsonNode>> it = root.fields();
-        while (it.hasNext()) {
-            Map.Entry<String, JsonNode> entry = it.next();
-            String name = entry.getKey();
-            Flavor flavor = parseFlavor(name, entry.getValue());
-            flavorMap.put(name, flavor);
+        for (int i = 0; i < root.size(); i++) {
+            Flavor flavor = parseFlavor(root.get(i));
+            flavorMap.put(flavor.name(), flavor);
         }
         return flavorMap;
     }
 
-    private static Flavor parseFlavor(String name, JsonNode node) {
+    private static Flavor parseFlavor(JsonNode node) {
+        String name = node.get(KEY_NAME).asText();
         Flavor.Builder builder = new Flavor.Builder(name, node.get(KEY_TEMPLATE_NAME).asText());
 
         if (node.has(KEY_TYPE)) {

--- a/address-controller-lib/src/test/java/enmasse/address/controller/api/v3/SerializationTest.java
+++ b/address-controller-lib/src/test/java/enmasse/address/controller/api/v3/SerializationTest.java
@@ -68,11 +68,11 @@ public class SerializationTest {
 
         ObjectNode deserialized = mapper.readValue(serialized, ObjectNode.class);
         assertThat(deserialized.get("kind").asText(), is("FlavorList"));
-        assertThat(deserialized.get("flavors").size(), is(2));
-        assertThat(deserialized.get("flavors").get("flavor1").get("type").asText(), is("queue"));
-        assertThat(deserialized.get("flavors").get("flavor1").get("description").asText(), is("Simple queue"));
-        assertThat(deserialized.get("flavors").get("flavor2").get("type").asText(), is("topic"));
-        assertThat(deserialized.get("flavors").get("flavor2").get("description").asText(), is("Simple topic"));
+        assertThat(deserialized.get("items").size(), is(2));
+        assertThat(deserialized.get("items").get(0).get("spec").get("type").asText(), is("queue"));
+        assertThat(deserialized.get("items").get(0).get("spec").get("description").asText(), is("Simple queue"));
+        assertThat(deserialized.get("items").get(1).get("spec").get("type").asText(), is("topic"));
+        assertThat(deserialized.get("items").get(1).get("spec").get("description").asText(), is("Simple topic"));
     }
 
     @Test

--- a/address-controller-lib/src/test/java/enmasse/address/controller/api/v3/amqp/AmqpFlavorsApiTest.java
+++ b/address-controller-lib/src/test/java/enmasse/address/controller/api/v3/amqp/AmqpFlavorsApiTest.java
@@ -55,11 +55,11 @@ public class AmqpFlavorsApiTest {
         ObjectNode json = decodeJson(response);
 
         assertThat(json.get("kind").asText(), is("FlavorList"));
-        assertThat(json.get("flavors").size(), is(2));
-        assertThat(json.get("flavors").get("flavor1").get("type").asText(), is("queue"));
-        assertThat(json.get("flavors").get("flavor1").get("description").asText(), is("Simple queue"));
-        assertThat(json.get("flavors").get("flavor2").get("type").asText(), is("topic"));
-        assertThat(json.get("flavors").get("flavor2").get("description").asText(), is("Simple topic"));
+        assertThat(json.get("items").size(), is(2));
+        assertThat(json.get("items").get(0).get("spec").get("type").asText(), is("queue"));
+        assertThat(json.get("items").get(0).get("spec").get("description").asText(), is("Simple queue"));
+        assertThat(json.get("items").get(1).get("spec").get("type").asText(), is("topic"));
+        assertThat(json.get("items").get(1).get("spec").get("description").asText(), is("Simple topic"));
     }
 
     @Test

--- a/address-controller-lib/src/test/resources/flavors.json
+++ b/address-controller-lib/src/test/resources/flavors.json
@@ -1,13 +1,15 @@
-{
-  "test-queue": {
+[
+  {
+    "name": "test-queue",
     "templateName": "queue-persisted",
     "templateParameters": {
       "STORAGE_CAPACITY": "2Gi"
     }
   },
-  "descriptive-queue": {
+  {
+    "name": "descriptive-queue",
     "templateName": "queue-inmemory",
     "type": "queue",
     "description": "This is a simple queue"
   }
-}
+]

--- a/address-controller-server/src/test/java/enmasse/address/controller/AMQPServerTest.java
+++ b/address-controller-server/src/test/java/enmasse/address/controller/AMQPServerTest.java
@@ -108,12 +108,9 @@ public class AMQPServerTest {
 
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode list = mapper.readValue((String)((AmqpValue)response.getBody()).getValue(), ObjectNode.class);
-        assertTrue(list.has("flavors"));
-        ObjectNode flavors = (ObjectNode) list.get("flavors");
-        assertTrue(flavors.has("vanilla"));
-        ObjectNode f = (ObjectNode) flavors.get("vanilla");
-        assertThat(f.get("type").asText(), is("queue"));
-        assertThat(f.get("description").asText(), is("Simple queue"));
+        assertThat(list.get("items").get(0).get("metadata").get("name").asText(), is("vanilla"));
+        assertThat(list.get("items").get(0).get("spec").get("type").asText(), is("queue"));
+        assertThat(list.get("items").get(0).get("spec").get("description").asText(), is("Simple queue"));
     }
 
 }

--- a/address-controller-server/src/test/java/enmasse/address/controller/HTTPServerTest.java
+++ b/address-controller-server/src/test/java/enmasse/address/controller/HTTPServerTest.java
@@ -73,8 +73,8 @@ public class HTTPServerTest {
             client.getNow(8080, "localhost", "/v3/address", response -> {
                 response.bodyHandler(buffer -> {
                     JsonObject data = buffer.toJsonObject();
-                    assertTrue(data.containsKey("addresses"));
-                    assertTrue(data.getJsonObject("addresses").containsKey("addr1"));
+                    assertTrue(data.containsKey("items"));
+                    assertThat(data.getJsonArray("items").getJsonObject(0).getJsonObject("metadata").getString("name"), is("addr1"));
                     latch.countDown();
                 });
             });
@@ -106,8 +106,8 @@ public class HTTPServerTest {
             client.getNow(8080, "localhost", "/v3/flavor", response -> {
                 response.bodyHandler(buffer -> {
                     JsonObject data = buffer.toJsonObject();
-                    assertTrue(data.containsKey("flavors"));
-                    assertTrue(data.getJsonObject("flavors").containsKey("vanilla"));
+                    assertTrue(data.containsKey("items"));
+                    assertThat(data.getJsonArray("items").getJsonObject(0).getJsonObject("metadata").getString("name"), is("vanilla"));
                     latch.countDown();
                 });
             });


### PR DESCRIPTION
This changes the format of Address and Flavor to be arrays of the resources in the same way as Pod and PodList in k8s. The ordering of flavors are the same as put into the config map. This closes #31 